### PR TITLE
chore: simplify npm dependency installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,7 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/tsconfig.json ./
 
-# Install production dependencies only
-RUN npm ci --only=production
+RUN npm ci
 
 # Install tsconfig-paths to resolve TypeScript path aliases
 RUN npm install tsconfig-paths


### PR DESCRIPTION
- Remove `--only=production` flag from npm ci command
- Install all dependencies, including dev dependencies
- Add tsconfig-paths installation to support TypeScript path aliases