### PR TITLE
chore: remove Jest from lint-staged configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "lint-staged": {
     "*.{js,ts}": [
       "prettier --write",
-      "eslint --fix",
-      "jest --bail --findRelatedTests --passWithNoTests"
+      "eslint --fix"
     ]
   },
   "author": "Kamal Sharif",


### PR DESCRIPTION
- Remove Jest test running from lint-staged pipeline
- Simplify pre-commit hooks to only run Prettier and ESLint